### PR TITLE
Error logging params fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed "Wrong number of arguments" error in call to `Logger#log_error` in `Sbmt::Outbox::ErrorTracker::error`
+
 ## [6.19.1] - 2025-02-20
 
 ### Fixed

--- a/lib/sbmt/outbox/error_tracker.rb
+++ b/lib/sbmt/outbox/error_tracker.rb
@@ -6,7 +6,7 @@ module Sbmt
       class << self
         def error(message, params = {})
           unless defined?(Sentry)
-            Outbox.logger.log_error(message, params)
+            Outbox.logger.log_error(message, **params)
             return
           end
 


### PR DESCRIPTION
Fixed Logger#log_error call to conform to Ruby v3 syntax

# Context

- Internal error logging fails with "ArgumentError wrong number of arguments (given 2, expected 1)" error

# What's inside

- [x] Fixed arguments to `Logger#log_error` call in `Sbmt::Outbox::ErrorTracker::error`